### PR TITLE
update(style-linter): adds css combinator logic to style linter

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,2 @@
 src/styles/normalize.scss
+src/styles/utilities/typography.scss

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,18 +1,10 @@
-// Transform from PascalCase to kebab-case
-const pascalToKebabCase = str => str.replace(/\.?([A-Z])/g, (char) =>  "-" + char.toLowerCase()).replace(/^-/, "");
-// Given a component name in PascalCase, returns a regex. The regex
-// must match CSS selectors conforming to the BEM naming conventions
-// you want to enforce.
-
-// BEM Styling Pattern
-const kebabCase = "[a-z#{}$]+(?:-[a-zA-Z0-9#{}$]+)*";
-const element = `(?:__${kebabCase})?`;
-const modifier = `(?:--${kebabCase})?`;
-const attribute = "(?:\\[.+\\])?";
-
-// Initial and Combinator Selector Configs
-const customBemSelector = (component, isInitial) => {
-  let block = isInitial ? pascalToKebabCase(component) : `(?:${kebabCase})?`;
+// BEM Selector Class Configs
+const customBemSelector = () => {
+  const kebabCase = "[a-z#{}$]+(?:-[a-zA-Z0-9#{}$]+)*";
+  let block = `(?:${kebabCase})?`;
+  const element = `(?:__${kebabCase})?`;
+  const modifier = `(?:--${kebabCase})?`;
+  const attribute = "(?:\\[.+\\])?";
   return new RegExp(`^\\.${block}${element}${modifier}${attribute}$`);
 };
 
@@ -28,10 +20,9 @@ module.exports = {
     "sh-waqar/declaration-use-variable": [["color", "background-color", { ignoreValues: ["inherit"] }]],
     "plugin/selector-bem-pattern": {
       preset: "bem",
-      implicitComponents: "src/components/**/*.scss",
+      implicitComponents: true,
       componentSelectors: {
-        initial: (component) => customBemSelector(component, true),
-        combined: (component) => customBemSelector(component, false)
+        initial: customBemSelector
       }
     },
     "order/order": [

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -3,9 +3,18 @@ const pascalToKebabCase = str => str.replace(/\.?([A-Z])/g, (char) =>  "-" + cha
 // Given a component name in PascalCase, returns a regex. The regex
 // must match CSS selectors conforming to the BEM naming conventions
 // you want to enforce.
-const customBemSelector = component => {
+const customInitialBemSelector = component => {
   const block = pascalToKebabCase(component);
   const kebabCase = "[a-z#{}$]+(?:-[a-zA-Z0-9#{}$]+)*";
+  const element = `(?:__${kebabCase})?`;
+  const modifier = `(?:--${kebabCase})?`;
+  const attribute = "(?:\\[.+\\])?";
+  return new RegExp(`^\\.${block}${element}${modifier}${attribute}$`);
+};
+
+const customCombinatorBemSelector = component => {
+  const kebabCase = "[a-z#{}$]+(?:-[a-zA-Z0-9#{}$]+)*";
+  const block = `(?:${kebabCase})?`;
   const element = `(?:__${kebabCase})?`;
   const modifier = `(?:--${kebabCase})?`;
   const attribute = "(?:\\[.+\\])?";
@@ -26,7 +35,8 @@ module.exports = {
       preset: "bem",
       implicitComponents: "src/components/**/*.scss",
       componentSelectors: {
-        initial: customBemSelector
+        initial: customInitialBemSelector,
+        combined: customCombinatorBemSelector
       }
     },
     "order/order": [

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -3,21 +3,16 @@ const pascalToKebabCase = str => str.replace(/\.?([A-Z])/g, (char) =>  "-" + cha
 // Given a component name in PascalCase, returns a regex. The regex
 // must match CSS selectors conforming to the BEM naming conventions
 // you want to enforce.
-const customInitialBemSelector = component => {
-  const block = pascalToKebabCase(component);
-  const kebabCase = "[a-z#{}$]+(?:-[a-zA-Z0-9#{}$]+)*";
-  const element = `(?:__${kebabCase})?`;
-  const modifier = `(?:--${kebabCase})?`;
-  const attribute = "(?:\\[.+\\])?";
-  return new RegExp(`^\\.${block}${element}${modifier}${attribute}$`);
-};
 
-const customCombinatorBemSelector = component => {
-  const kebabCase = "[a-z#{}$]+(?:-[a-zA-Z0-9#{}$]+)*";
-  const block = `(?:${kebabCase})?`;
-  const element = `(?:__${kebabCase})?`;
-  const modifier = `(?:--${kebabCase})?`;
-  const attribute = "(?:\\[.+\\])?";
+// BEM Styling Pattern
+const kebabCase = "[a-z#{}$]+(?:-[a-zA-Z0-9#{}$]+)*";
+const element = `(?:__${kebabCase})?`;
+const modifier = `(?:--${kebabCase})?`;
+const attribute = "(?:\\[.+\\])?";
+
+// Initial and Combinator Selector Configs
+const customBemSelector = (component, isInitial) => {
+  let block = isInitial ? pascalToKebabCase(component) : `(?:${kebabCase})?`;
   return new RegExp(`^\\.${block}${element}${modifier}${attribute}$`);
 };
 
@@ -35,8 +30,8 @@ module.exports = {
       preset: "bem",
       implicitComponents: "src/components/**/*.scss",
       componentSelectors: {
-        initial: customInitialBemSelector,
-        combined: customCombinatorBemSelector
+        initial: (component) => customBemSelector(component, true),
+        combined: (component) => customBemSelector(component, false)
       }
     },
     "order/order": [

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -288,7 +288,7 @@ module.exports = {
       "ignore": ["stylelint-commands", "after-comment"]
     } ],
     "declaration-colon-space-after": "always",
-    "max-empty-lines": 2,
+    "max-empty-lines": 1,
     "rule-empty-line-before": [ "always", {
       "except": ["first-nested"],
       "ignore": ["after-comment"]


### PR DESCRIPTION
# Description

Adds style lint logic for css combinators. Achieved by adding combinator Regexp under combined configs. 

The use of combinators are allowed but must still follow the kebab case and element modifier convention: 

```
.container {
  // Styles...
 
  .card {
     // Styles
  }
}
